### PR TITLE
Anchor comment prefix regex to start of line

### DIFF
--- a/lib/configparser.ex
+++ b/lib/configparser.ex
@@ -266,8 +266,8 @@ defmodule ConfigParser do
   end
 
   # Returns true if the line appears to be a comment
-  @hash_comment_regex ~r{#.*}
-  @semicolon_comment_regex ~r{;.*}
+  @hash_comment_regex ~r{^#.*}
+  @semicolon_comment_regex ~r{^;.*}
 
   defp is_comment(line) do
     String.strip(line) =~ @hash_comment_regex || String.strip(line) =~ @semicolon_comment_regex

--- a/test/configparser_test.exs
+++ b/test/configparser_test.exs
@@ -244,6 +244,9 @@ defmodule ConfigParserTest do
       [You can use comments]
       # like this
       ; or this
+          # and also this
+      but not # like this
+      and also ; not this
 
       # By default only in an empty line.
       # Inline comments can be harmful because they prevent users
@@ -275,7 +278,9 @@ defmodule ConfigParserTest do
      "spaces around the delimiter" => "obviously",
      "spaces in keys" => "allowed", "spaces in values" => "allowed as well",
      "you can also use" => "to delimit keys from values"},
-   "You can use comments" => %{}}} )
+   "You can use comments" => %{
+     "but not # like this" => nil,
+     "and also" => nil}}} )
 
   end
 end


### PR DESCRIPTION
Following the comment prefix rules defined in Pyhton's configparser
docs, comment prefix characters that don't appear at the beginning of a
line (ignoring whitespace). The regex to match comments was updated
accordingly.

Here's the quoted definition of a comment prefix from the configparser
docs:

> Comment prefixes are strings that indicate the start of a valid comment
> within a config file. comment_prefixes are used only on otherwise empty
> lines (optionally indented) whereas inline_comment_prefixes can be used
> after every valid value (e.g. section names, options and empty lines as
> well). By default inline comments are disabled and '#' and ';' are used
> as prefixes for whole line comments.
>
> Changed in version 3.2: In previous versions of configparser behaviour
> matched comment_prefixes=('#',';') and inline_comment_prefixes=(';',).