### PR TITLE
Close file after parsing string

### DIFF
--- a/lib/configparser.ex
+++ b/lib/configparser.ex
@@ -47,7 +47,9 @@ defmodule ConfigParser do
   def parse_string(config_string) do
     {:ok, pid} = StringIO.open(config_string)
     line_stream = IO.stream(pid, :line)
-    parse_stream(line_stream)
+    result = parse_stream(line_stream)
+    StringIO.close(pid)
+    result
   end
 
   @doc """

--- a/test/configparser_test.exs
+++ b/test/configparser_test.exs
@@ -108,6 +108,13 @@ defmodule ConfigParserTest do
       """, {:ok, %{"section" => %{"key" => "value"}}} )
   end
 
+  test "close StringIO after read" do
+    process_count_before = Process.list |> length
+    ConfigParser.parse_string("test")
+    process_count_after = Process.list |> length
+    assert process_count_before == process_count_after
+  end
+
   test "extracts a list of sections from parsed config data" do
       {:ok, parse_result} = ConfigParser.parse_string("""
         [first_section]


### PR DESCRIPTION
Process count has increased one by one for every `ConfigParser.parse_string/1` function is called. Because `StringIO.open(config_string)` is used for reading string then return result without closing it (`StringIO.close(pid)`)