### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,30 @@
-/_build
-/deps
-/doc
-mix.lock
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore package tarball (built via "mix hex.build").
+configparser_ex-*.tar
+
+# Temporary files for e.g. tests.
+/tmp/
+
+# Misc.
+mix.lock
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,51 @@
-4.0.0 - Changed the way that strings get parsed to use new functionality
+# Changelog
+
+## 4.0.0
+
+Changed the way that strings get parsed to use new functionality
 (added in Elixir 1.7) where `StringIO.open` can accept a function for working
 with the device that is automatically closed when the function completes. Since
 this changes the minimum Elixir version this is a major version release.
 
-3.0.1 - Fixed compiler warnings for Elixir 1.7.1 and later
+## 3.0.1
 
-3.0.0 - This represents a significant change for multi-line values.  Prior to
+Fixed compiler warnings for Elixir 1.7.1 and later
+
+## 3.0.0
+
+This represents a significant change for multi-line values.  Prior to
 version 3, the parser would join multi-line values using a single space.  The
 Python ConfigParser library, in contrast, joins them with a newline.  This
 version joins the lines of a multi-line value with a newline like Python does.
 It also adds parser options, in particular the `join_continuations` option,
 which should allow users to continue using a space if desired.
 
-2.0.1 - When parsing from a string, the library opened a `StringIO` device which
+## 2.0.1
+
+When parsing from a string, the library opened a `StringIO` device which
 it never closed.  This release fixes the problem.  Thanks to @vietkungfu on
 GitHub.
 
-2.0.0 - Replaced calls to deprecated String.strip with String.trim.  Makes
+## 2.0.0
+
+Replaced calls to deprecated String.strip with String.trim.  Makes
 minimum Elixir Version 1.3.  If you need to run on versions prior to 1.3 you
 can use the 1.0.0 version.  Bumped the major version as this may be a breaking
 change for some folks.
 
-1.0.0 - Changed the way comments were parsed to make it more compatible with
+## 1.0.0
+
+Changed the way comments were parsed to make it more compatible with
 other libraries
 
-0.2.1 - Small code changes to address a compiler warning from Elixir 1.2.3
+## 0.2.1
 
-0.1.0
-0.2.0 - Identical releases caused by author's inexperience with hex
+Small code changes to address a compiler warning from Elixir 1.2.3
+
+## 0.2.0
+
+Identical releases caused by author's inexperience with Hex
+
+## 0.1.0
+
+Initial release

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-ConfigParser
-============
+# ConfigParser for Elixir
+
 [![BuildStatus](https://travis-ci.org/easco/configparser_ex.svg?branch=master)](https://travis-ci.org/easco/configparser_ex)
+[![Module Version](https://img.shields.io/hexpm/v/configparser_ex.svg)](https://hex.pm/packages/configparser_ex)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/configparser_ex/)
+[![Total Download](https://img.shields.io/hexpm/dt/configparser_ex.svg)](https://hex.pm/packages/configparser_ex)
+[![License](https://img.shields.io/hexpm/l/configparser_ex.svg)](https://github.com/easco/configparser_ex/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/easco/configparser_ex.svg)](https://github.com/easco/configparser_ex/commits/master)
 
 This library implements a parser for config files in the style of Windows INI, as parsed by the Python [configparser](https://docs.python.org/3/library/configparser.html) library.
-
----
 
 ### A note about Mix.Config
 
@@ -12,8 +15,6 @@ This library is intended for compatibility in environments that are already
 using files in the `configparser` format. For most uses in Elixir, consider
 using `Mix.Config` instead as it is part of the core library and provides
 similar functionality.
-
----
 
 > **Release Notes**
 >
@@ -24,11 +25,9 @@ similar functionality.
 > The release now includes parser options and the `join_continuations` option
 > with the value `:with_space` will revert the library to its prior behavior.
 
----
-
 Basic config files look like this:
 
-```
+```ini
 # Comments can be placed in the file on lines with a hash
 [config section]
 
@@ -37,7 +36,7 @@ second_key = another_value
 ```
 The file shown in this sample defines a section called `config section` and then defines two config settings in key-value form.  The result of parsing this file would be:
 
-```
+```elixir
 {:ok,
  %{"config section" => %{"first_key" => "value",
      "second_key" => "another_value"}}}
@@ -45,14 +44,13 @@ The file shown in this sample defines a section called `config section` and then
 
 The `:ok` atom in the first part of the tuple indicates that parsing was successful.  The map in the second part of the tuple has keys that are the sections created in the file and the values are themselves value maps.  The value maps reflect the keys and values defined within that section.
 
-Config Definitions
-------------------
+## Config Definitions
 
 A section definition is simply the name of the section enclosed in square brackets `[like this]`.  Section names can contain spaces.
 
 Within a section, configuration definitions are key value pairs.  On a definition line, the key and value are separated by either a colon (:) or an equal sign (=):
 
-```
+```ini
 [key-value samples]
 key_defined = with_an_equal_sign
 another_key_defined : with_a_colon
@@ -61,7 +59,7 @@ values = can have spaces too
 ```
 The value of a particular key can extend over more than one line.  The follow-on lines must be indented farther than the first line.
 
-```
+```ini
 [multi-line sample]
 this key's value : continues on more than one line
     but the follow on lines must be indented
@@ -70,18 +68,17 @@ this key's value : continues on more than one line
 
 It is possible to define keys with values that are either null or the empty string:
 
-```
+```ini
 [empty-ish values]
 this_key_has_a_nil_value
 this_key_has_the_empty_string_as_a_value =
 ```
 
-Comments
------------
+## Comments
 
 The config file can contain comments:
 
-```
+```ini
 # comments can begin with a hash or number sign a the beginning
 ; or a comment line can begin with a semicolon
 
@@ -89,24 +86,23 @@ The config file can contain comments:
 when defining a key = this is the value ; a comment starting with a semicolon
 ```
 
-Using the Parser
-----------------
+## Using the Parser
 
 The `ConfigParser` module includes routines that can parse a file, the contents of a string, or from a stream of lines.
 
 To parse the content of a config file call the `parse_file` function and pass the file's path:
 
-```
-  {:ok, parse_result} = ConfigParser.parse_file("/path/to/file")
+```elixir
+{:ok, parse_result} = ConfigParser.parse_file("/path/to/file")
 ```
 
 To parse config information out of a string, call the `parse_string` method:
 
-```
-  {:ok, parse_result} = ConfigParser.parse_string("""
-    [interesting_config]
-    config_key = some interesting value
-    """)
+```elixir
+{:ok, parse_result} = ConfigParser.parse_string("""
+  [interesting_config]
+  config_key = some interesting value
+  """)
 ```
 
 Given a stream whose elements represent the successive lines of a config file, the library can parse the content of the stream:
@@ -120,13 +116,11 @@ As mentioned previously the result of doing the parsing is a tuple.  If successf
 
 If the parser encounters an error, then the first part of the tuple will be the atom `:error` and the second element will be a string describing the error that was encountered:
 
-```
+```elixir
 {:error, "Syntax Error on line 3"}
 ```
-    ---
 
-Parser Options
---------------
+## Parser Options
 
 Starting with Version 3 of the library, it is possible to pass options to the parser:
 
@@ -137,11 +131,11 @@ Starting with Version 3 of the library, it is possible to pass options to the pa
 
 You may add options as keyword arguments to the end of the `parse_file`, `parse_string`, or `parse_stream` functions
 
-    {:ok, parse_result} = ConfigParser.parse_file("/path/to/file", join_continuations: :with_newline)
+```elixir
+{:ok, parse_result} = ConfigParser.parse_file("/path/to/file", join_continuations: :with_newline)
+```
 
-
-Not Implemented
----------------
+## Not Implemented
 
 This library is primarily intended to provide backward-compatibility in environments that already use config files. It does not handle creating, manipulating, or writing config files.  It treats config files as read-only entities.
 
@@ -150,3 +144,9 @@ This library currently returns the parsed result as a raw data structure.
 It does not support the value interpolation in the Python library and does not implement the DEFAULT section as described in the Python documentation.
 
 This library does not support the Python ConfigParser's customization features.
+
+## Copyright and License
+
+Copyright (c) 2015 R. Scott Thompson
+
+Released under the BSD License, which can be found in the repository in [`LICENSE`](https://github.com/easco/configparser_ex).

--- a/mix.exs
+++ b/mix.exs
@@ -1,46 +1,52 @@
 defmodule ConfigParser.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/easco/configparser_ex"
+
   def project do
     [
       app: :configparser_ex,
       version: "4.0.0",
       name: "ConfigParser for Elixir",
-      source_url: "https://github.com/easco/configparser_ex",
+      source_url: @source_url,
       elixir: ">= 1.7.0",
-      description:
-        "A module that parses INI-like files. Not unlike the Python configparser package.",
       package: package(),
-      deps: deps()
+      deps: deps(),
+      docs: docs()
     ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type `mix help compile.app` for more information
   def application do
     []
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type `mix help deps` for more examples and options
   defp deps do
-    [{:earmark, "~> 1.3", only: :dev}, {:ex_doc, "~> 0.19", only: :dev}]
+    [
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
+    ]
   end
 
   defp package do
     [
+      description: """
+      A module that parses INI-like files. Not unlike the Python configparser
+      package.
+      """,
       maintainers: ["Scott Thompson"],
-      files: ["mix.exs", "lib", "LICENSE*", "README*"],
-      licenses: ["bsd"],
-      links: %{"GitHub" => "https://github.com/easco/configparser_ex"}
+      files: ["mix.exs", "lib", "LICENSE*", "README*", "CHANGELOG*"],
+      licenses: ["BSD"],
+      links: %{
+        "Changelog" => "https://hexdocs.pm/configparser_ex/changelog.html",
+        "GitHub" => @source_url}
+    ]
+  end
+
+  defp docs do
+    [
+      extras: ["CHANGELOG.md", {:"README.md", [title: "Overview"]}],
+      main: "readme",
+      source_url: @source_url,
+      formatters: ["html"]
     ]
   end
 end


### PR DESCRIPTION
Besides other changes, this commit ensures the generated HTML doc for
HexDocs.pm will become the main source doc for this Elixir library which
leverage on ExDoc features.

List of changes:
* Refactor project config
* Use common source url
* Set readme as main html page
* Add changelog to html doc
* Add changelog link to hex info page
* Update gitignore
* Add formatter config
* Add copyright license section
* Fix markdowns
* Update main page title
* Set output to html
* Badges and more badges!

Screenshot:

![Screenshot-20210311224933-2662x1464](https://user-images.githubusercontent.com/134518/110806491-148ac280-82bd-11eb-88cb-94aadc000e2d.png)
