### PR TITLE
Use SPDX ID for licenses in mixfile

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule ConfigParser.Mixfile do
       """,
       maintainers: ["Scott Thompson"],
       files: ["mix.exs", "lib", "LICENSE*", "README*", "CHANGELOG*"],
-      licenses: ["BSD"],
+      licenses: ["BSD-3-Clause"],
       links: %{
         "Changelog" => "https://hexdocs.pm/configparser_ex/changelog.html",
         "GitHub" => @source_url}


### PR DESCRIPTION
Hex.pm recommends this, and it helps tools identify exactly which BSD license this project is released under.