### PR TITLE
Add support for alternative map

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ You may add options as keyword arguments to the end of the `parse_file`, `parse_
 {:ok, parse_result} = ConfigParser.parse_file("/path/to/file", join_continuations: :with_newline)
 ```
 
+## Alternative Map Implementations
+
+By default, `configparser_ex` uses `Map` provided by Elixir. It also supports other `Map`-compatible implementations.
+
+For example, if you want to use an order-preserving map implementation, try [`ordered_map`](https://github.com/jonnystorm/ordered-map-elixir) with following configuration:
+
+```elixir
+config :configparser_ex, map_implementation: OrderedMap
+```
+
 ## Not Implemented
 
 This library is primarily intended to provide backward-compatibility in environments that already use config files. It does not handle creating, manipulating, or writing config files.  It treats config files as read-only entities.

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,24 +1,4 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for third-
-# party users, it should be done in your mix.exs file.
-
-# Sample configuration:
-#
-#     config :logger, :console,
-#       level: :info,
-#       format: "$date $time [$level] $metadata$message\n",
-#       metadata: [:user_id]
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+config :configparser_ex,
+  map_implementation: Map

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,11 @@
 use Mix.Config
 
-config :configparser_ex,
-  map_implementation: Map
+case Mix.env() do
+  :test_alternative_map ->
+    config :configparser_ex,
+      map_implementation: OrderedMap
+
+  _ ->
+    config :configparser_ex,
+      map_implementation: Map
+end

--- a/lib/ConfigParser/ParseState.ex
+++ b/lib/ConfigParser/ParseState.ex
@@ -5,7 +5,7 @@
       join_continuations: :with_newline
     }
 
-    @map OrderedMap
+    @map Application.get_env(:configparser_ex, :map_implementation)
 
     defstruct line_number: 1,               # What line of the "file" are we parsing
           current_section: nil,             # Section that definitions go into

--- a/lib/ConfigParser/ParseState.ex
+++ b/lib/ConfigParser/ParseState.ex
@@ -1,93 +1,104 @@
- defmodule ConfigParser.ParseState do
-    @moduledoc false
+defmodule ConfigParser.ParseState do
+  @moduledoc false
 
-    @default_options %{
-      join_continuations: :with_newline
-    }
+  @default_options %{
+    join_continuations: :with_newline
+  }
 
-    @map Application.get_env(:configparser_ex, :map_implementation)
+  @map Application.get_env(:configparser_ex, :map_implementation)
 
-    defstruct line_number: 1,               # What line of the "file" are we parsing
-          current_section: nil,             # Section that definitions go into
-              last_indent: 0,               # The amount of whitespace on the last line
-            continuation?: false,           # Could the line being parsed be a coninuation
-                 last_key: nil,             # If this is a continuation, which key would it continue
-                   result: {:ok, @map.new()},      # The result as it is being built.
-                  options: @default_options # options used when parsing the config
-    alias __MODULE__
+  # What line of the "file" are we parsing
+  defstruct line_number: 1,
+            # Section that definitions go into
+            current_section: nil,
+            # The amount of whitespace on the last line
+            last_indent: 0,
+            # Could the line being parsed be a coninuation
+            continuation?: false,
+            # If this is a continuation, which key would it continue
+            last_key: nil,
+            # The result as it is being built.
+            result: {:ok, @map.new()},
+            # options used when parsing the config
+            options: @default_options
 
-    def default_options, do: @default_options
+  alias __MODULE__
 
-    def begin_section(parse_state, new_section) do
-      # Create a new result, based on the old, with the new section added
-      {:ok, section_map} = parse_state.result
+  def default_options, do: @default_options
 
-      # Only add a new section if it's not already there
-      section_key = String.trim(new_section)
+  def begin_section(parse_state, new_section) do
+    # Create a new result, based on the old, with the new section added
+    {:ok, section_map} = parse_state.result
 
-      new_result =
-        if @map.has_key?(section_map, section_key) do
-          # don't change the result if they section already exists
-          parse_state.result
-        else
-          # add the section as an empty map if it doesn't exist
-          {:ok, @map.put(section_map, section_key, @map.new()) }
-        end
+    # Only add a new section if it's not already there
+    section_key = String.trim(new_section)
 
-      # next line cannot be a continuation
-      %{parse_state | current_section: section_key,
-                               result: new_result,
-                        continuation?: false,
-                             last_key: nil}
-    end
-
-    def define_config(parse_state, key, value) do
-      {:ok, section_map} = parse_state.result
-
-      if parse_state.current_section != nil do
-        # pull the values out for the section that's currently being built
-        value_map = section_map[parse_state.current_section]
-
-        # create a new set of values by adding the key/value pair passed in
-        new_values =
-          if value == nil do
-            @map.put(value_map, String.trim(key), nil)
-          else
-
-            @map.put(value_map, String.trim(key), String.trim(value))
-          end
-
-        # create a new result replacing the current section with thenew values
-        new_result = {:ok, @map.put(section_map, parse_state.current_section, new_values)}
-
-        # The next line could be a continuation of this value so set continuation to true
-        # and store the key that we're defining now.
-        %{parse_state | result: new_result,
-                 continuation?: true,
-                      last_key: String.trim(key)}
+    new_result =
+      if @map.has_key?(section_map, section_key) do
+        # don't change the result if they section already exists
+        parse_state.result
       else
-        new_result = {:error, "A configuration section must be defined before defining configuration values in line #{parse_state.line_number}"}
-        %{parse_state | result: new_result}
+        # add the section as an empty map if it doesn't exist
+        {:ok, @map.put(section_map, section_key, @map.new())}
       end
-    end
 
-    def append_continuation(%ParseState{options: options} = parse_state, continuation_value) do
-      {:ok, section_map} = parse_state.result
+    # next line cannot be a continuation
+    %{
+      parse_state
+      | current_section: section_key,
+        result: new_result,
+        continuation?: false,
+        last_key: nil
+    }
+  end
 
+  def define_config(parse_state, key, value) do
+    {:ok, section_map} = parse_state.result
+
+    if parse_state.current_section != nil do
       # pull the values out for the section that's currently being built
       value_map = section_map[parse_state.current_section]
 
       # create a new set of values by adding the key/value pair passed in
-      new_value = append_continuation(options, value_map[parse_state.last_key], continuation_value)
+      new_values =
+        if value == nil do
+          @map.put(value_map, String.trim(key), nil)
+        else
+          @map.put(value_map, String.trim(key), String.trim(value))
+        end
 
-      define_config(parse_state, parse_state.last_key, new_value)
-    end
+      # create a new result replacing the current section with thenew values
+      new_result = {:ok, @map.put(section_map, parse_state.current_section, new_values)}
 
-    defp append_continuation(%{join_continuations: :with_newline}, value, continuation) do
-      "#{value}\n#{continuation}"
-    end
+      # The next line could be a continuation of this value so set continuation to true
+      # and store the key that we're defining now.
+      %{parse_state | result: new_result, continuation?: true, last_key: String.trim(key)}
+    else
+      new_result =
+        {:error,
+         "A configuration section must be defined before defining configuration values in line #{parse_state.line_number}"}
 
-    defp append_continuation(%{join_continuations: :with_space}, value, continuation) do
-      "#{value} #{continuation}"
+      %{parse_state | result: new_result}
     end
   end
+
+  def append_continuation(%ParseState{options: options} = parse_state, continuation_value) do
+    {:ok, section_map} = parse_state.result
+
+    # pull the values out for the section that's currently being built
+    value_map = section_map[parse_state.current_section]
+
+    # create a new set of values by adding the key/value pair passed in
+    new_value = append_continuation(options, value_map[parse_state.last_key], continuation_value)
+
+    define_config(parse_state, parse_state.last_key, new_value)
+  end
+
+  defp append_continuation(%{join_continuations: :with_newline}, value, continuation) do
+    "#{value}\n#{continuation}"
+  end
+
+  defp append_continuation(%{join_continuations: :with_space}, value, continuation) do
+    "#{value} #{continuation}"
+  end
+end

--- a/lib/configparser.ex
+++ b/lib/configparser.ex
@@ -74,10 +74,11 @@ defmodule ConfigParser do
     Parse a string as if it was the content of a config file.
   """
   def parse_string(config_string, parser_options \\ []) do
-    {:ok, result} = StringIO.open(config_string, fn io_device ->
-      line_stream = IO.stream(io_device, :line)
-      parse_stream(line_stream, parser_options)
-    end)
+    {:ok, result} =
+      StringIO.open(config_string, fn io_device ->
+        line_stream = IO.stream(io_device, :line)
+        parse_stream(line_stream, parser_options)
+      end)
 
     result
   end

--- a/lib/configparser.ex
+++ b/lib/configparser.ex
@@ -1,6 +1,8 @@
 defmodule ConfigParser do
   alias ConfigParser.ParseState, as: ParseState
 
+  @map OrderedMap
+
   @moduledoc """
     The ConfigParser library implements a parser for config files in the style of Windows INI,
     as parsed by the Python [configparser](https://docs.python.org/3/library/configparser.html) library.
@@ -104,7 +106,7 @@ defmodule ConfigParser do
     Return a list of sections in the given config parser state
   """
   def sections(parser_results) do
-    Map.keys(parser_results)
+    @map.keys(parser_results)
   end
 
   @doc """
@@ -120,7 +122,7 @@ defmodule ConfigParser do
   """
   def options(parser_results, in_section) do
     if has_section?(parser_results, in_section) do
-      Map.keys(parser_results[in_section])
+      @map.keys(parser_results[in_section])
     else
       nil
     end

--- a/lib/configparser.ex
+++ b/lib/configparser.ex
@@ -1,7 +1,7 @@
 defmodule ConfigParser do
   alias ConfigParser.ParseState, as: ParseState
 
-  @map OrderedMap
+  @map Application.get_env(:configparser_ex, :map_implementation)
 
   @moduledoc """
     The ConfigParser library implements a parser for config files in the style of Windows INI,

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,8 @@ defmodule ConfigParser.Mixfile do
 
   defp deps do
     [
-      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
+      {:ordered_map, "~> 0.0.5", only: [:dev, :test]}
     ]
   end
 
@@ -37,7 +38,8 @@ defmodule ConfigParser.Mixfile do
       licenses: ["BSD"],
       links: %{
         "Changelog" => "https://hexdocs.pm/configparser_ex/changelog.html",
-        "GitHub" => @source_url}
+        "GitHub" => @source_url
+      }
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,8 @@ defmodule ConfigParser.Mixfile do
       elixir: ">= 1.7.0",
       package: package(),
       deps: deps(),
-      docs: docs()
+      docs: docs(),
+      aliases: aliases()
     ]
   end
 
@@ -23,7 +24,7 @@ defmodule ConfigParser.Mixfile do
   defp deps do
     [
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-      {:ordered_map, "~> 0.0.5", only: [:dev, :test]}
+      {:ordered_map, "~> 0.0.5", only: [:dev, :test, :test_alternative_map]}
     ]
   end
 
@@ -50,5 +51,25 @@ defmodule ConfigParser.Mixfile do
       source_url: @source_url,
       formatters: ["html"]
     ]
+  end
+
+  defp aliases do
+    [
+      {:"test.all", [&test/1, &test_alternative_map/1]}
+    ]
+  end
+
+  defp test(_) do
+    Mix.shell().cmd(
+      "mix test test/configparser_test.exs",
+      env: [{"MIX_ENV", "test"}]
+    )
+  end
+
+  defp test_alternative_map(_) do
+    Mix.shell().cmd(
+      "mix test test/configparser_alternative_map_test.exs",
+      env: [{"MIX_ENV", "test_alternative_map"}]
+    )
   end
 end

--- a/test/configparser_alternative_map_test.exs
+++ b/test/configparser_alternative_map_test.exs
@@ -1,0 +1,594 @@
+defmodule ConfigParserAlternativeMapTest do
+  @moduledoc """
+  Test alternative map with OrderedMap.
+  """
+
+  use ExUnit.Case
+
+  def check_string(string, against_value) do
+    assert against_value == ConfigParser.parse_string(string)
+  end
+
+  test "parses an empty file" do
+    check_string("", {:ok, %OrderedMap{keys: [], map: %{}, size: 0}})
+  end
+
+  test "parses an comment only file" do
+    check_string("#this is a useless file\n", {:ok, %OrderedMap{keys: [], map: %{}, size: 0}})
+  end
+
+  test "parses comments and empty lines" do
+    check_string(
+      """
+      #this is a useless file
+
+        # filled with comments and empty lines
+      """,
+      {:ok, %OrderedMap{keys: [], map: %{}, size: 0}}
+    )
+  end
+
+  test "parses a single section" do
+    check_string("[section]\n", {
+      :ok,
+      %OrderedMap{
+        keys: ["section"],
+        map: %{
+          "section" => %OrderedMap{
+            keys: [],
+            map: %{},
+            size: 0
+          }
+        },
+        size: 1
+      }
+    })
+  end
+
+  test "parses a section name with a space" do
+    check_string("[section with space]\n", {
+      :ok,
+      %OrderedMap{
+        keys: ["section with space"],
+        map: %{
+          "section with space" => %OrderedMap{
+            keys: [],
+            map: %{},
+            size: 0
+          }
+        },
+        size: 1
+      }
+    })
+  end
+
+  test "parses a config option into a section" do
+    check_string(
+      """
+      [section]
+      # this is an interesting key value pair
+      key = value
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["section"],
+          map: %{"section" => %OrderedMap{keys: ["key"], map: %{"key" => "value"}, size: 1}},
+          size: 1
+        }
+      }
+    )
+  end
+
+  test "allows spaces in the keys" do
+    check_string(
+      """
+      [section]
+      # this is an interesting key value pair
+      spaces in keys=allowed
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["section"],
+          map: %{
+            "section" => %OrderedMap{
+              keys: ["spaces in keys"],
+              map: %{"spaces in keys" => "allowed"},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
+  end
+
+  test "allows spaces in the values" do
+    check_string(
+      """
+      [section]
+      # this is an interesting key value pair
+      spaces in values=allowed as well
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["section"],
+          map: %{
+            "section" => %OrderedMap{
+              keys: ["spaces in values"],
+              map: %{"spaces in values" => "allowed as well"},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
+  end
+
+  test "allows spaces around the delimiter" do
+    check_string(
+      """
+      [section]
+      # this is an interesting key value pair
+      spaces around the delimiter = obviously
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["section"],
+          map: %{
+            "section" => %OrderedMap{
+              keys: ["spaces around the delimiter"],
+              map: %{"spaces around the delimiter" => "obviously"},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
+  end
+
+  test "allows a colon as the delimiter" do
+    check_string(
+      """
+      [section]
+      # this is an interesting key value pair
+      you can also use : to delimit keys from values
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["section"],
+          map: %{
+            "section" => %OrderedMap{
+              keys: ["you can also use"],
+              map: %{"you can also use" => "to delimit keys from values"},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
+  end
+
+  test "allows a continuation line" do
+    check_string(
+      """
+      [section]
+      you can also use : to delimit keys from values
+          and add a continuation
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["section"],
+          map: %{
+            "section" => %OrderedMap{
+              keys: ["you can also use"],
+              map: %{"you can also use" => "to delimit keys from values\nand add a continuation"},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
+  end
+
+  test "allows a multi-line continuation" do
+    check_string(
+      """
+      [section]
+      you can also use : to delimit keys
+          from values
+          and add a continuation
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["section"],
+          map: %{
+            "section" => %OrderedMap{
+              keys: ["you can also use"],
+              map: %{"you can also use" => "to delimit keys\nfrom values\nand add a continuation"},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
+  end
+
+  test "allows empty string thing" do
+    check_string(
+      """
+      [No Values]
+      empty string value here =
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["No Values"],
+          map: %{
+            "No Values" => %OrderedMap{
+              keys: ["empty string value here"],
+              map: %{"empty string value here" => ""},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
+  end
+
+  test "allows lone keys" do
+    check_string(
+      """
+      [No Values]
+      key_without_value
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["No Values"],
+          map: %{
+            "No Values" => %OrderedMap{
+              keys: ["key_without_value"],
+              map: %{"key_without_value" => nil},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
+  end
+
+  test "parses a config option with an inline comment" do
+    check_string(
+      """
+      [section]
+      # this is an interesting key value pair
+      key = value ; With a comment
+      """,
+      {:ok,
+       %OrderedMap{
+         keys: ["section"],
+         map: %{"section" => %OrderedMap{keys: ["key"], map: %{"key" => "value"}, size: 1}},
+         size: 1
+       }}
+    )
+  end
+
+  test "close StringIO after read" do
+    process_count_before = Process.list() |> length
+    ConfigParser.parse_string("test")
+    process_count_after = Process.list() |> length
+    assert process_count_before == process_count_after
+  end
+
+  test "extracts a list of sections from parsed config data" do
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [first_section]
+      boring = value
+      [second_section]
+      someother_key = and_value
+      """)
+
+    sorted_sections = Enum.sort(ConfigParser.sections(parse_result), &(&1 < &2))
+    assert sorted_sections == ["first_section", "second_section"]
+  end
+
+  test "determines if a particular section is found in the parsed results" do
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [first_section]
+      boring = value
+      [second_section]
+      someother_key = and_value
+      """)
+
+    assert true == ConfigParser.has_section?(parse_result, "first_section")
+    assert false == ConfigParser.has_section?(parse_result, "snarfblat")
+  end
+
+  test "returns a list of the options defined in a particular section" do
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      two = for the show
+      three = to get ready
+      """)
+
+    sorted_options = Enum.sort(ConfigParser.options(parse_result, "section"), &(&1 < &2))
+    assert sorted_options == ["one", "three", "two"]
+
+    assert nil == ConfigParser.options(parse_result, "non-existant section")
+  end
+
+  test "determines if a particuliar option is available in a section" do
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      two = for the show
+      three = to get ready
+      """)
+
+    assert ConfigParser.has_option?(parse_result, "section", "one") == true
+    assert ConfigParser.has_option?(parse_result, "section", "florp") == false
+  end
+
+  test "returns nil if asked for a value in a section that doesn't exist" do
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      """)
+
+    assert ConfigParser.get(parse_result, "non-existant", "one") == nil
+  end
+
+  test "returns the value of a particular option when no fancy options are provided" do
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      """)
+
+    assert ConfigParser.get(parse_result, "section", "one") == "for the money"
+  end
+
+  test "allows the :vars option to override definitions from the parse data" do
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      """)
+
+    assert ConfigParser.get(parse_result, "section", "one",
+             vars: %{
+               "one" => "is the loneliest number"
+             }
+           ) == "is the loneliest number"
+
+    assert ConfigParser.get(parse_result, "section", "one",
+             vars: %{
+               "one" => nil
+             }
+           ) == nil
+  end
+
+  test "returns the fallback value if the value can't be found otherwise" do
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      """)
+
+    assert ConfigParser.get(parse_result, "non-existant", "_", fallback: "None") == "None"
+    assert ConfigParser.get(parse_result, "section", "non-existant", fallback: "None") == "None"
+  end
+
+  test "correctly handles the case where a section is repeated or reopened" do
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+        [Simple Values]
+        key=value
+        spaces in keys=allowed
+
+        [Simple Values]
+        spaces in values=allowed as well
+        spaces around the delimiter = obviously
+        you can also use : to delimit keys from values
+      """)
+
+    assert ConfigParser.get(parse_result, "Simple Values", "key") == "value"
+
+    assert ConfigParser.get(parse_result, "Simple Values", "spaces in values") ==
+             "allowed as well"
+  end
+
+  describe "parsing options" do
+    test "errors out with unrecognized options" do
+      assert {:error, _} =
+               ConfigParser.parse_string(
+                 """
+                   [does not matter]
+                   this = is_bogus
+                 """,
+                 unrecognized_option: "whatever"
+               )
+    end
+
+    test "parses multiline_values when asked for spaces" do
+      {:ok, parse_result} =
+        ConfigParser.parse_string(
+          """
+          [section]
+          you can also use : to delimit keys from values
+              and add a continuation
+          """,
+          join_continuations: :with_space
+        )
+
+      assert parse_result == %OrderedMap{
+               keys: ["section"],
+               map: %{
+                 "section" => %OrderedMap{
+                   keys: ["you can also use"],
+                   map: %{
+                     "you can also use" => "to delimit keys from values and add a continuation"
+                   },
+                   size: 1
+                 }
+               },
+               size: 1
+             }
+    end
+  end
+
+  test "parses extended example from python page" do
+    check_string(
+      """
+      [Simple Values]
+      key=value
+      spaces in keys=allowed
+      spaces in values=allowed as well
+      spaces around the delimiter = obviously
+      you can also use : to delimit keys from values
+
+      [All Values Are Strings]
+      values like this: 1000000
+      or this: 3.14159265359
+      are they treated as numbers? : no
+      integers, floats and booleans are held as: strings
+      can use the API to get converted values directly: true
+
+      [Multiline Values]
+      chorus: I'm a lumberjack, and I'm okay,
+          I sleep all night and I work all day
+
+      [No Values]
+      key_without_value
+      empty string value here =
+
+      [You can use comments]
+      # like this
+      ; or this
+          # and also this
+      but not # like this
+      and also ; not this
+
+      # By default only in an empty line.
+      # Inline comments can be harmful because they prevent users
+      # from using the delimiting characters as parts of values.
+      # That being said, this can be customized.
+
+          [Sections Can Be Indented]
+              can_values_be_as_well = True
+              does_that_mean_anything_special = False
+              purpose = formatting for readability
+              multiline_values = are
+                  handled just fine as
+                  long as they are indented
+                  deeper than the first line
+                  of a value
+              # Did I mention we can indent comments, too?
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: [
+            "Sections Can Be Indented",
+            "You can use comments",
+            "No Values",
+            "Multiline Values",
+            "All Values Are Strings",
+            "Simple Values"
+          ],
+          map: %{
+            "All Values Are Strings" => %OrderedMap{
+              keys: [
+                "can use the API to get converted values directly",
+                "integers, floats and booleans are held as",
+                "are they treated as numbers?",
+                "or this",
+                "values like this"
+              ],
+              map: %{
+                "are they treated as numbers?" => "no",
+                "can use the API to get converted values directly" => "true",
+                "integers, floats and booleans are held as" => "strings",
+                "or this" => "3.14159265359",
+                "values like this" => "1000000"
+              },
+              size: 5
+            },
+            "Multiline Values" => %OrderedMap{
+              keys: ["chorus"],
+              map: %{
+                "chorus" =>
+                  "I'm a lumberjack, and I'm okay,\nI sleep all night and I work all day"
+              },
+              size: 1
+            },
+            "No Values" => %OrderedMap{
+              keys: ["empty string value here", "key_without_value"],
+              map: %{"empty string value here" => "", "key_without_value" => nil},
+              size: 2
+            },
+            "Sections Can Be Indented" => %OrderedMap{
+              keys: [
+                "multiline_values",
+                "purpose",
+                "does_that_mean_anything_special",
+                "can_values_be_as_well"
+              ],
+              map: %{
+                "can_values_be_as_well" => "True",
+                "does_that_mean_anything_special" => "False",
+                "multiline_values" =>
+                  "are\nhandled just fine as\nlong as they are indented\ndeeper than the first line\nof a value",
+                "purpose" => "formatting for readability"
+              },
+              size: 4
+            },
+            "Simple Values" => %OrderedMap{
+              keys: [
+                "you can also use",
+                "spaces around the delimiter",
+                "spaces in values",
+                "spaces in keys",
+                "key"
+              ],
+              map: %{
+                "key" => "value",
+                "spaces around the delimiter" => "obviously",
+                "spaces in keys" => "allowed",
+                "spaces in values" => "allowed as well",
+                "you can also use" => "to delimit keys from values"
+              },
+              size: 5
+            },
+            "You can use comments" => %OrderedMap{
+              keys: ["and also", "but not # like this"],
+              map: %{"and also" => nil, "but not # like this" => nil},
+              size: 2
+            }
+          },
+          size: 6
+        }
+      }
+    )
+  end
+end

--- a/test/configparser_test.exs
+++ b/test/configparser_test.exs
@@ -6,245 +6,456 @@ defmodule ConfigParserTest do
   end
 
   test "parses an empty file" do
-    check_string("", {:ok, %{}})
+    check_string("", {:ok, %OrderedMap{keys: [], map: %{}, size: 0}})
   end
 
   test "parses an comment only file" do
-    check_string("#this is a useless file\n", {:ok, %{}})
+    check_string("#this is a useless file\n", {:ok, %OrderedMap{keys: [], map: %{}, size: 0}})
   end
 
   test "parses comments and empty lines" do
-    check_string("""
+    check_string(
+      """
       #this is a useless file
 
         # filled with comments and empty lines
-      """, {:ok, %{}} )
+      """,
+      {:ok, %OrderedMap{keys: [], map: %{}, size: 0}}
+    )
   end
 
   test "parses a single section" do
-    check_string("[section]\n", {:ok, %{"section" => %{}}} )
+    check_string("[section]\n", {
+      :ok,
+      %OrderedMap{
+        keys: ["section"],
+        map: %{
+          "section" => %OrderedMap{
+            keys: [],
+            map: %{},
+            size: 0
+          }
+        },
+        size: 1
+      }
+    })
   end
 
   test "parses a section name with a space" do
-    check_string("[section with space]\n", {:ok, %{"section with space" => %{}}} )
+    check_string("[section with space]\n", {
+      :ok,
+      %OrderedMap{
+        keys: ["section with space"],
+        map: %{
+          "section with space" => %OrderedMap{
+            keys: [],
+            map: %{},
+            size: 0
+          }
+        },
+        size: 1
+      }
+    })
   end
 
   test "parses a config option into a section" do
-    check_string("""
+    check_string(
+      """
       [section]
       # this is an interesting key value pair
       key = value
-      """, {:ok, %{"section" => %{"key" => "value"}}} )
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["section"],
+          map: %{"section" => %OrderedMap{keys: ["key"], map: %{"key" => "value"}, size: 1}},
+          size: 1
+        }
+      }
+    )
   end
 
   test "allows spaces in the keys" do
-    check_string("""
+    check_string(
+      """
       [section]
       # this is an interesting key value pair
       spaces in keys=allowed
-      """, {:ok, %{"section" => %{"spaces in keys" => "allowed"}}} )
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["section"],
+          map: %{
+            "section" => %OrderedMap{
+              keys: ["spaces in keys"],
+              map: %{"spaces in keys" => "allowed"},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
   end
 
   test "allows spaces in the values" do
-    check_string("""
+    check_string(
+      """
       [section]
       # this is an interesting key value pair
       spaces in values=allowed as well
-      """, {:ok, %{"section" => %{"spaces in values" => "allowed as well"}}} )
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["section"],
+          map: %{
+            "section" => %OrderedMap{
+              keys: ["spaces in values"],
+              map: %{"spaces in values" => "allowed as well"},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
   end
 
   test "allows spaces around the delimiter" do
-    check_string("""
+    check_string(
+      """
       [section]
       # this is an interesting key value pair
       spaces around the delimiter = obviously
-      """, {:ok, %{"section" => %{"spaces around the delimiter" => "obviously"}}} )
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["section"],
+          map: %{
+            "section" => %OrderedMap{
+              keys: ["spaces around the delimiter"],
+              map: %{"spaces around the delimiter" => "obviously"},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
   end
 
   test "allows a colon as the delimiter" do
-    check_string("""
+    check_string(
+      """
       [section]
       # this is an interesting key value pair
       you can also use : to delimit keys from values
-      """, {:ok, %{"section" => %{"you can also use" => "to delimit keys from values"}}} )
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["section"],
+          map: %{
+            "section" => %OrderedMap{
+              keys: ["you can also use"],
+              map: %{"you can also use" => "to delimit keys from values"},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
   end
 
   test "allows a continuation line" do
-    check_string("""
+    check_string(
+      """
       [section]
       you can also use : to delimit keys from values
           and add a continuation
-      """, {:ok, %{"section" => %{"you can also use" => "to delimit keys from values\nand add a continuation"}}} )
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["section"],
+          map: %{
+            "section" => %OrderedMap{
+              keys: ["you can also use"],
+              map: %{"you can also use" => "to delimit keys from values\nand add a continuation"},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
   end
 
   test "allows a multi-line continuation" do
-    check_string("""
+    check_string(
+      """
       [section]
-      you can also use : to delimit keys 
+      you can also use : to delimit keys
           from values
           and add a continuation
-      """, {:ok, %{"section" => %{"you can also use" => "to delimit keys\nfrom values\nand add a continuation"}}} )
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["section"],
+          map: %{
+            "section" => %OrderedMap{
+              keys: ["you can also use"],
+              map: %{"you can also use" => "to delimit keys\nfrom values\nand add a continuation"},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
   end
 
   test "allows empty string thing" do
-    check_string("""
+    check_string(
+      """
       [No Values]
       empty string value here =
-      """, {:ok, %{"No Values" => %{"empty string value here" => ""}}} )
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["No Values"],
+          map: %{
+            "No Values" => %OrderedMap{
+              keys: ["empty string value here"],
+              map: %{"empty string value here" => ""},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
   end
 
   test "allows lone keys" do
-    check_string("""
+    check_string(
+      """
       [No Values]
       key_without_value
-      """, {:ok, %{"No Values" => %{"key_without_value" => nil}}} )
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: ["No Values"],
+          map: %{
+            "No Values" => %OrderedMap{
+              keys: ["key_without_value"],
+              map: %{"key_without_value" => nil},
+              size: 1
+            }
+          },
+          size: 1
+        }
+      }
+    )
   end
 
   test "parses a config option with an inline comment" do
-    check_string("""
+    check_string(
+      """
       [section]
       # this is an interesting key value pair
       key = value ; With a comment
-      """, {:ok, %{"section" => %{"key" => "value"}}} )
+      """,
+      {:ok,
+       %OrderedMap{
+         keys: ["section"],
+         map: %{"section" => %OrderedMap{keys: ["key"], map: %{"key" => "value"}, size: 1}},
+         size: 1
+       }}
+    )
   end
 
   test "close StringIO after read" do
-    process_count_before = Process.list |> length
+    process_count_before = Process.list() |> length
     ConfigParser.parse_string("test")
-    process_count_after = Process.list |> length
+    process_count_after = Process.list() |> length
     assert process_count_before == process_count_after
   end
 
   test "extracts a list of sections from parsed config data" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [first_section]
-        boring = value
-        [second_section]
-        someother_key = and_value
-        """)
-      sorted_sections = Enum.sort(ConfigParser.sections(parse_result), &(&1 < &2))
-      assert sorted_sections == ["first_section", "second_section"]
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [first_section]
+      boring = value
+      [second_section]
+      someother_key = and_value
+      """)
+
+    sorted_sections = Enum.sort(ConfigParser.sections(parse_result), &(&1 < &2))
+    assert sorted_sections == ["first_section", "second_section"]
   end
 
   test "determines if a particular section is found in the parsed results" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [first_section]
-        boring = value
-        [second_section]
-        someother_key = and_value
-        """)
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [first_section]
+      boring = value
+      [second_section]
+      someother_key = and_value
+      """)
 
-      assert true == ConfigParser.has_section?(parse_result, "first_section")
-      assert false == ConfigParser.has_section?(parse_result, "snarfblat")
+    assert true == ConfigParser.has_section?(parse_result, "first_section")
+    assert false == ConfigParser.has_section?(parse_result, "snarfblat")
   end
 
   test "returns a list of the options defined in a particular section" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [section]
-        one = for the money
-        two = for the show
-        three = to get ready
-        """)
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      two = for the show
+      three = to get ready
+      """)
 
-      sorted_options = Enum.sort(ConfigParser.options(parse_result, "section"), &(&1 < &2))
-      assert sorted_options == ["one", "three", "two"]
+    sorted_options = Enum.sort(ConfigParser.options(parse_result, "section"), &(&1 < &2))
+    assert sorted_options == ["one", "three", "two"]
 
-      assert nil == ConfigParser.options(parse_result, "non-existant section")
+    assert nil == ConfigParser.options(parse_result, "non-existant section")
   end
 
   test "determines if a particuliar option is available in a section" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [section]
-        one = for the money
-        two = for the show
-        three = to get ready
-        """)
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      two = for the show
+      three = to get ready
+      """)
 
-      assert ConfigParser.has_option?(parse_result, "section", "one") == true
-      assert ConfigParser.has_option?(parse_result, "section", "florp") == false
+    assert ConfigParser.has_option?(parse_result, "section", "one") == true
+    assert ConfigParser.has_option?(parse_result, "section", "florp") == false
   end
 
   test "returns nil if asked for a value in a section that doesn't exist" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [section]
-        one = for the money
-        """)
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      """)
 
-      assert ConfigParser.get(parse_result, "non-existant", "one") == nil
+    assert ConfigParser.get(parse_result, "non-existant", "one") == nil
   end
 
   test "returns the value of a particular option when no fancy options are provided" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [section]
-        one = for the money
-        """)
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      """)
 
-      assert ConfigParser.get(parse_result, "section", "one") == "for the money"
+    assert ConfigParser.get(parse_result, "section", "one") == "for the money"
   end
 
   test "allows the :vars option to override definitions from the parse data" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [section]
-        one = for the money
-        """)
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      """)
 
-      assert ConfigParser.get(parse_result, "section", "one", vars: %{
-          "one" => "is the loneliest number"
-        }) == "is the loneliest number"
+    assert ConfigParser.get(parse_result, "section", "one",
+             vars: %{
+               "one" => "is the loneliest number"
+             }
+           ) == "is the loneliest number"
 
-      assert ConfigParser.get(parse_result, "section", "one", vars: %{
-          "one" => nil
-        }) == nil
+    assert ConfigParser.get(parse_result, "section", "one",
+             vars: %{
+               "one" => nil
+             }
+           ) == nil
   end
 
   test "returns the fallback value if the value can't be found otherwise" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [section]
-        one = for the money
-        """)
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      """)
 
-      assert ConfigParser.get(parse_result, "non-existant", "_", fallback: "None") == "None"
-      assert ConfigParser.get(parse_result, "section", "non-existant", fallback: "None") == "None"
+    assert ConfigParser.get(parse_result, "non-existant", "_", fallback: "None") == "None"
+    assert ConfigParser.get(parse_result, "section", "non-existant", fallback: "None") == "None"
   end
 
   test "correctly handles the case where a section is repeated or reopened" do
-    {:ok, parse_result} = ConfigParser.parse_string("""
-      [Simple Values]
-      key=value
-      spaces in keys=allowed
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+        [Simple Values]
+        key=value
+        spaces in keys=allowed
 
-      [Simple Values]
-      spaces in values=allowed as well
-      spaces around the delimiter = obviously
-      you can also use : to delimit keys from values
-    """)
+        [Simple Values]
+        spaces in values=allowed as well
+        spaces around the delimiter = obviously
+        you can also use : to delimit keys from values
+      """)
 
     assert ConfigParser.get(parse_result, "Simple Values", "key") == "value"
-    assert ConfigParser.get(parse_result, "Simple Values", "spaces in values") == "allowed as well"
+
+    assert ConfigParser.get(parse_result, "Simple Values", "spaces in values") ==
+             "allowed as well"
   end
 
   describe "parsing options" do
     test "errors out with unrecognized options" do
-      assert {:error, _} = ConfigParser.parse_string("""
-        [does not matter]
-        this = is_bogus
-      """, unrecognized_option: "whatever")
+      assert {:error, _} =
+               ConfigParser.parse_string(
+                 """
+                   [does not matter]
+                   this = is_bogus
+                 """,
+                 unrecognized_option: "whatever"
+               )
     end
-    
+
     test "parses multiline_values when asked for spaces" do
+      {:ok, parse_result} =
+        ConfigParser.parse_string(
+          """
+          [section]
+          you can also use : to delimit keys from values
+              and add a continuation
+          """,
+          join_continuations: :with_space
+        )
 
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [section]
-        you can also use : to delimit keys from values
-            and add a continuation
-        """, join_continuations: :with_space)
-
-      assert parse_result == %{"section" => %{"you can also use" => "to delimit keys from values and add a continuation"}}
+      assert parse_result == %OrderedMap{
+               keys: ["section"],
+               map: %{
+                 "section" => %OrderedMap{
+                   keys: ["you can also use"],
+                   map: %{
+                     "you can also use" => "to delimit keys from values and add a continuation"
+                   },
+                   size: 1
+                 }
+               },
+               size: 1
+             }
     end
   end
 
   test "parses extended example from python page" do
-    check_string("""
+    check_string(
+      """
       [Simple Values]
       key=value
       spaces in keys=allowed
@@ -289,24 +500,91 @@ defmodule ConfigParserTest do
                   deeper than the first line
                   of a value
               # Did I mention we can indent comments, too?
-      """, {:ok, %{"All Values Are Strings" => %{"are they treated as numbers?" => "no",
-     "can use the API to get converted values directly" => "true",
-     "integers, floats and booleans are held as" => "strings",
-     "or this" => "3.14159265359", "values like this" => "1000000"},
-   "Multiline Values" => %{"chorus" => "I'm a lumberjack, and I'm okay,\nI sleep all night and I work all day"},
-   "No Values" => %{"empty string value here" => "",
-     "key_without_value" => nil},
-   "Sections Can Be Indented" => %{"can_values_be_as_well" => "True",
-     "does_that_mean_anything_special" => "False",
-     "multiline_values" => "are\nhandled just fine as\nlong as they are indented\ndeeper than the first line\nof a value",
-     "purpose" => "formatting for readability"},
-   "Simple Values" => %{"key" => "value",
-     "spaces around the delimiter" => "obviously",
-     "spaces in keys" => "allowed", "spaces in values" => "allowed as well",
-     "you can also use" => "to delimit keys from values"},
-   "You can use comments" => %{
-     "but not # like this" => nil,
-     "and also" => nil}}} )
-
+      """,
+      {
+        :ok,
+        %OrderedMap{
+          keys: [
+            "Sections Can Be Indented",
+            "You can use comments",
+            "No Values",
+            "Multiline Values",
+            "All Values Are Strings",
+            "Simple Values"
+          ],
+          map: %{
+            "All Values Are Strings" => %OrderedMap{
+              keys: [
+                "can use the API to get converted values directly",
+                "integers, floats and booleans are held as",
+                "are they treated as numbers?",
+                "or this",
+                "values like this"
+              ],
+              map: %{
+                "are they treated as numbers?" => "no",
+                "can use the API to get converted values directly" => "true",
+                "integers, floats and booleans are held as" => "strings",
+                "or this" => "3.14159265359",
+                "values like this" => "1000000"
+              },
+              size: 5
+            },
+            "Multiline Values" => %OrderedMap{
+              keys: ["chorus"],
+              map: %{
+                "chorus" =>
+                  "I'm a lumberjack, and I'm okay,\nI sleep all night and I work all day"
+              },
+              size: 1
+            },
+            "No Values" => %OrderedMap{
+              keys: ["empty string value here", "key_without_value"],
+              map: %{"empty string value here" => "", "key_without_value" => nil},
+              size: 2
+            },
+            "Sections Can Be Indented" => %OrderedMap{
+              keys: [
+                "multiline_values",
+                "purpose",
+                "does_that_mean_anything_special",
+                "can_values_be_as_well"
+              ],
+              map: %{
+                "can_values_be_as_well" => "True",
+                "does_that_mean_anything_special" => "False",
+                "multiline_values" =>
+                  "are\nhandled just fine as\nlong as they are indented\ndeeper than the first line\nof a value",
+                "purpose" => "formatting for readability"
+              },
+              size: 4
+            },
+            "Simple Values" => %OrderedMap{
+              keys: [
+                "you can also use",
+                "spaces around the delimiter",
+                "spaces in values",
+                "spaces in keys",
+                "key"
+              ],
+              map: %{
+                "key" => "value",
+                "spaces around the delimiter" => "obviously",
+                "spaces in keys" => "allowed",
+                "spaces in values" => "allowed as well",
+                "you can also use" => "to delimit keys from values"
+              },
+              size: 5
+            },
+            "You can use comments" => %OrderedMap{
+              keys: ["and also", "but not # like this"],
+              map: %{"and also" => nil, "but not # like this" => nil},
+              size: 2
+            }
+          },
+          size: 6
+        }
+      }
+    )
   end
 end

--- a/test/configparser_test.exs
+++ b/test/configparser_test.exs
@@ -6,456 +6,245 @@ defmodule ConfigParserTest do
   end
 
   test "parses an empty file" do
-    check_string("", {:ok, %OrderedMap{keys: [], map: %{}, size: 0}})
+    check_string("", {:ok, %{}})
   end
 
   test "parses an comment only file" do
-    check_string("#this is a useless file\n", {:ok, %OrderedMap{keys: [], map: %{}, size: 0}})
+    check_string("#this is a useless file\n", {:ok, %{}})
   end
 
   test "parses comments and empty lines" do
-    check_string(
-      """
+    check_string("""
       #this is a useless file
 
         # filled with comments and empty lines
-      """,
-      {:ok, %OrderedMap{keys: [], map: %{}, size: 0}}
-    )
+      """, {:ok, %{}} )
   end
 
   test "parses a single section" do
-    check_string("[section]\n", {
-      :ok,
-      %OrderedMap{
-        keys: ["section"],
-        map: %{
-          "section" => %OrderedMap{
-            keys: [],
-            map: %{},
-            size: 0
-          }
-        },
-        size: 1
-      }
-    })
+    check_string("[section]\n", {:ok, %{"section" => %{}}} )
   end
 
   test "parses a section name with a space" do
-    check_string("[section with space]\n", {
-      :ok,
-      %OrderedMap{
-        keys: ["section with space"],
-        map: %{
-          "section with space" => %OrderedMap{
-            keys: [],
-            map: %{},
-            size: 0
-          }
-        },
-        size: 1
-      }
-    })
+    check_string("[section with space]\n", {:ok, %{"section with space" => %{}}} )
   end
 
   test "parses a config option into a section" do
-    check_string(
-      """
+    check_string("""
       [section]
       # this is an interesting key value pair
       key = value
-      """,
-      {
-        :ok,
-        %OrderedMap{
-          keys: ["section"],
-          map: %{"section" => %OrderedMap{keys: ["key"], map: %{"key" => "value"}, size: 1}},
-          size: 1
-        }
-      }
-    )
+      """, {:ok, %{"section" => %{"key" => "value"}}} )
   end
 
   test "allows spaces in the keys" do
-    check_string(
-      """
+    check_string("""
       [section]
       # this is an interesting key value pair
       spaces in keys=allowed
-      """,
-      {
-        :ok,
-        %OrderedMap{
-          keys: ["section"],
-          map: %{
-            "section" => %OrderedMap{
-              keys: ["spaces in keys"],
-              map: %{"spaces in keys" => "allowed"},
-              size: 1
-            }
-          },
-          size: 1
-        }
-      }
-    )
+      """, {:ok, %{"section" => %{"spaces in keys" => "allowed"}}} )
   end
 
   test "allows spaces in the values" do
-    check_string(
-      """
+    check_string("""
       [section]
       # this is an interesting key value pair
       spaces in values=allowed as well
-      """,
-      {
-        :ok,
-        %OrderedMap{
-          keys: ["section"],
-          map: %{
-            "section" => %OrderedMap{
-              keys: ["spaces in values"],
-              map: %{"spaces in values" => "allowed as well"},
-              size: 1
-            }
-          },
-          size: 1
-        }
-      }
-    )
+      """, {:ok, %{"section" => %{"spaces in values" => "allowed as well"}}} )
   end
 
   test "allows spaces around the delimiter" do
-    check_string(
-      """
+    check_string("""
       [section]
       # this is an interesting key value pair
       spaces around the delimiter = obviously
-      """,
-      {
-        :ok,
-        %OrderedMap{
-          keys: ["section"],
-          map: %{
-            "section" => %OrderedMap{
-              keys: ["spaces around the delimiter"],
-              map: %{"spaces around the delimiter" => "obviously"},
-              size: 1
-            }
-          },
-          size: 1
-        }
-      }
-    )
+      """, {:ok, %{"section" => %{"spaces around the delimiter" => "obviously"}}} )
   end
 
   test "allows a colon as the delimiter" do
-    check_string(
-      """
+    check_string("""
       [section]
       # this is an interesting key value pair
       you can also use : to delimit keys from values
-      """,
-      {
-        :ok,
-        %OrderedMap{
-          keys: ["section"],
-          map: %{
-            "section" => %OrderedMap{
-              keys: ["you can also use"],
-              map: %{"you can also use" => "to delimit keys from values"},
-              size: 1
-            }
-          },
-          size: 1
-        }
-      }
-    )
+      """, {:ok, %{"section" => %{"you can also use" => "to delimit keys from values"}}} )
   end
 
   test "allows a continuation line" do
-    check_string(
-      """
+    check_string("""
       [section]
       you can also use : to delimit keys from values
           and add a continuation
-      """,
-      {
-        :ok,
-        %OrderedMap{
-          keys: ["section"],
-          map: %{
-            "section" => %OrderedMap{
-              keys: ["you can also use"],
-              map: %{"you can also use" => "to delimit keys from values\nand add a continuation"},
-              size: 1
-            }
-          },
-          size: 1
-        }
-      }
-    )
+      """, {:ok, %{"section" => %{"you can also use" => "to delimit keys from values\nand add a continuation"}}} )
   end
 
   test "allows a multi-line continuation" do
-    check_string(
-      """
+    check_string("""
       [section]
-      you can also use : to delimit keys
+      you can also use : to delimit keys 
           from values
           and add a continuation
-      """,
-      {
-        :ok,
-        %OrderedMap{
-          keys: ["section"],
-          map: %{
-            "section" => %OrderedMap{
-              keys: ["you can also use"],
-              map: %{"you can also use" => "to delimit keys\nfrom values\nand add a continuation"},
-              size: 1
-            }
-          },
-          size: 1
-        }
-      }
-    )
+      """, {:ok, %{"section" => %{"you can also use" => "to delimit keys\nfrom values\nand add a continuation"}}} )
   end
 
   test "allows empty string thing" do
-    check_string(
-      """
+    check_string("""
       [No Values]
       empty string value here =
-      """,
-      {
-        :ok,
-        %OrderedMap{
-          keys: ["No Values"],
-          map: %{
-            "No Values" => %OrderedMap{
-              keys: ["empty string value here"],
-              map: %{"empty string value here" => ""},
-              size: 1
-            }
-          },
-          size: 1
-        }
-      }
-    )
+      """, {:ok, %{"No Values" => %{"empty string value here" => ""}}} )
   end
 
   test "allows lone keys" do
-    check_string(
-      """
+    check_string("""
       [No Values]
       key_without_value
-      """,
-      {
-        :ok,
-        %OrderedMap{
-          keys: ["No Values"],
-          map: %{
-            "No Values" => %OrderedMap{
-              keys: ["key_without_value"],
-              map: %{"key_without_value" => nil},
-              size: 1
-            }
-          },
-          size: 1
-        }
-      }
-    )
+      """, {:ok, %{"No Values" => %{"key_without_value" => nil}}} )
   end
 
   test "parses a config option with an inline comment" do
-    check_string(
-      """
+    check_string("""
       [section]
       # this is an interesting key value pair
       key = value ; With a comment
-      """,
-      {:ok,
-       %OrderedMap{
-         keys: ["section"],
-         map: %{"section" => %OrderedMap{keys: ["key"], map: %{"key" => "value"}, size: 1}},
-         size: 1
-       }}
-    )
+      """, {:ok, %{"section" => %{"key" => "value"}}} )
   end
 
   test "close StringIO after read" do
-    process_count_before = Process.list() |> length
+    process_count_before = Process.list |> length
     ConfigParser.parse_string("test")
-    process_count_after = Process.list() |> length
+    process_count_after = Process.list |> length
     assert process_count_before == process_count_after
   end
 
   test "extracts a list of sections from parsed config data" do
-    {:ok, parse_result} =
-      ConfigParser.parse_string("""
-      [first_section]
-      boring = value
-      [second_section]
-      someother_key = and_value
-      """)
-
-    sorted_sections = Enum.sort(ConfigParser.sections(parse_result), &(&1 < &2))
-    assert sorted_sections == ["first_section", "second_section"]
+      {:ok, parse_result} = ConfigParser.parse_string("""
+        [first_section]
+        boring = value
+        [second_section]
+        someother_key = and_value
+        """)
+      sorted_sections = Enum.sort(ConfigParser.sections(parse_result), &(&1 < &2))
+      assert sorted_sections == ["first_section", "second_section"]
   end
 
   test "determines if a particular section is found in the parsed results" do
-    {:ok, parse_result} =
-      ConfigParser.parse_string("""
-      [first_section]
-      boring = value
-      [second_section]
-      someother_key = and_value
-      """)
+      {:ok, parse_result} = ConfigParser.parse_string("""
+        [first_section]
+        boring = value
+        [second_section]
+        someother_key = and_value
+        """)
 
-    assert true == ConfigParser.has_section?(parse_result, "first_section")
-    assert false == ConfigParser.has_section?(parse_result, "snarfblat")
+      assert true == ConfigParser.has_section?(parse_result, "first_section")
+      assert false == ConfigParser.has_section?(parse_result, "snarfblat")
   end
 
   test "returns a list of the options defined in a particular section" do
-    {:ok, parse_result} =
-      ConfigParser.parse_string("""
-      [section]
-      one = for the money
-      two = for the show
-      three = to get ready
-      """)
+      {:ok, parse_result} = ConfigParser.parse_string("""
+        [section]
+        one = for the money
+        two = for the show
+        three = to get ready
+        """)
 
-    sorted_options = Enum.sort(ConfigParser.options(parse_result, "section"), &(&1 < &2))
-    assert sorted_options == ["one", "three", "two"]
+      sorted_options = Enum.sort(ConfigParser.options(parse_result, "section"), &(&1 < &2))
+      assert sorted_options == ["one", "three", "two"]
 
-    assert nil == ConfigParser.options(parse_result, "non-existant section")
+      assert nil == ConfigParser.options(parse_result, "non-existant section")
   end
 
   test "determines if a particuliar option is available in a section" do
-    {:ok, parse_result} =
-      ConfigParser.parse_string("""
-      [section]
-      one = for the money
-      two = for the show
-      three = to get ready
-      """)
+      {:ok, parse_result} = ConfigParser.parse_string("""
+        [section]
+        one = for the money
+        two = for the show
+        three = to get ready
+        """)
 
-    assert ConfigParser.has_option?(parse_result, "section", "one") == true
-    assert ConfigParser.has_option?(parse_result, "section", "florp") == false
+      assert ConfigParser.has_option?(parse_result, "section", "one") == true
+      assert ConfigParser.has_option?(parse_result, "section", "florp") == false
   end
 
   test "returns nil if asked for a value in a section that doesn't exist" do
-    {:ok, parse_result} =
-      ConfigParser.parse_string("""
-      [section]
-      one = for the money
-      """)
+      {:ok, parse_result} = ConfigParser.parse_string("""
+        [section]
+        one = for the money
+        """)
 
-    assert ConfigParser.get(parse_result, "non-existant", "one") == nil
+      assert ConfigParser.get(parse_result, "non-existant", "one") == nil
   end
 
   test "returns the value of a particular option when no fancy options are provided" do
-    {:ok, parse_result} =
-      ConfigParser.parse_string("""
-      [section]
-      one = for the money
-      """)
+      {:ok, parse_result} = ConfigParser.parse_string("""
+        [section]
+        one = for the money
+        """)
 
-    assert ConfigParser.get(parse_result, "section", "one") == "for the money"
+      assert ConfigParser.get(parse_result, "section", "one") == "for the money"
   end
 
   test "allows the :vars option to override definitions from the parse data" do
-    {:ok, parse_result} =
-      ConfigParser.parse_string("""
-      [section]
-      one = for the money
-      """)
+      {:ok, parse_result} = ConfigParser.parse_string("""
+        [section]
+        one = for the money
+        """)
 
-    assert ConfigParser.get(parse_result, "section", "one",
-             vars: %{
-               "one" => "is the loneliest number"
-             }
-           ) == "is the loneliest number"
+      assert ConfigParser.get(parse_result, "section", "one", vars: %{
+          "one" => "is the loneliest number"
+        }) == "is the loneliest number"
 
-    assert ConfigParser.get(parse_result, "section", "one",
-             vars: %{
-               "one" => nil
-             }
-           ) == nil
+      assert ConfigParser.get(parse_result, "section", "one", vars: %{
+          "one" => nil
+        }) == nil
   end
 
   test "returns the fallback value if the value can't be found otherwise" do
-    {:ok, parse_result} =
-      ConfigParser.parse_string("""
-      [section]
-      one = for the money
-      """)
+      {:ok, parse_result} = ConfigParser.parse_string("""
+        [section]
+        one = for the money
+        """)
 
-    assert ConfigParser.get(parse_result, "non-existant", "_", fallback: "None") == "None"
-    assert ConfigParser.get(parse_result, "section", "non-existant", fallback: "None") == "None"
+      assert ConfigParser.get(parse_result, "non-existant", "_", fallback: "None") == "None"
+      assert ConfigParser.get(parse_result, "section", "non-existant", fallback: "None") == "None"
   end
 
   test "correctly handles the case where a section is repeated or reopened" do
-    {:ok, parse_result} =
-      ConfigParser.parse_string("""
-        [Simple Values]
-        key=value
-        spaces in keys=allowed
+    {:ok, parse_result} = ConfigParser.parse_string("""
+      [Simple Values]
+      key=value
+      spaces in keys=allowed
 
-        [Simple Values]
-        spaces in values=allowed as well
-        spaces around the delimiter = obviously
-        you can also use : to delimit keys from values
-      """)
+      [Simple Values]
+      spaces in values=allowed as well
+      spaces around the delimiter = obviously
+      you can also use : to delimit keys from values
+    """)
 
     assert ConfigParser.get(parse_result, "Simple Values", "key") == "value"
-
-    assert ConfigParser.get(parse_result, "Simple Values", "spaces in values") ==
-             "allowed as well"
+    assert ConfigParser.get(parse_result, "Simple Values", "spaces in values") == "allowed as well"
   end
 
   describe "parsing options" do
     test "errors out with unrecognized options" do
-      assert {:error, _} =
-               ConfigParser.parse_string(
-                 """
-                   [does not matter]
-                   this = is_bogus
-                 """,
-                 unrecognized_option: "whatever"
-               )
+      assert {:error, _} = ConfigParser.parse_string("""
+        [does not matter]
+        this = is_bogus
+      """, unrecognized_option: "whatever")
     end
-
+    
     test "parses multiline_values when asked for spaces" do
-      {:ok, parse_result} =
-        ConfigParser.parse_string(
-          """
-          [section]
-          you can also use : to delimit keys from values
-              and add a continuation
-          """,
-          join_continuations: :with_space
-        )
 
-      assert parse_result == %OrderedMap{
-               keys: ["section"],
-               map: %{
-                 "section" => %OrderedMap{
-                   keys: ["you can also use"],
-                   map: %{
-                     "you can also use" => "to delimit keys from values and add a continuation"
-                   },
-                   size: 1
-                 }
-               },
-               size: 1
-             }
+      {:ok, parse_result} = ConfigParser.parse_string("""
+        [section]
+        you can also use : to delimit keys from values
+            and add a continuation
+        """, join_continuations: :with_space)
+
+      assert parse_result == %{"section" => %{"you can also use" => "to delimit keys from values and add a continuation"}}
     end
   end
 
   test "parses extended example from python page" do
-    check_string(
-      """
+    check_string("""
       [Simple Values]
       key=value
       spaces in keys=allowed
@@ -500,91 +289,24 @@ defmodule ConfigParserTest do
                   deeper than the first line
                   of a value
               # Did I mention we can indent comments, too?
-      """,
-      {
-        :ok,
-        %OrderedMap{
-          keys: [
-            "Sections Can Be Indented",
-            "You can use comments",
-            "No Values",
-            "Multiline Values",
-            "All Values Are Strings",
-            "Simple Values"
-          ],
-          map: %{
-            "All Values Are Strings" => %OrderedMap{
-              keys: [
-                "can use the API to get converted values directly",
-                "integers, floats and booleans are held as",
-                "are they treated as numbers?",
-                "or this",
-                "values like this"
-              ],
-              map: %{
-                "are they treated as numbers?" => "no",
-                "can use the API to get converted values directly" => "true",
-                "integers, floats and booleans are held as" => "strings",
-                "or this" => "3.14159265359",
-                "values like this" => "1000000"
-              },
-              size: 5
-            },
-            "Multiline Values" => %OrderedMap{
-              keys: ["chorus"],
-              map: %{
-                "chorus" =>
-                  "I'm a lumberjack, and I'm okay,\nI sleep all night and I work all day"
-              },
-              size: 1
-            },
-            "No Values" => %OrderedMap{
-              keys: ["empty string value here", "key_without_value"],
-              map: %{"empty string value here" => "", "key_without_value" => nil},
-              size: 2
-            },
-            "Sections Can Be Indented" => %OrderedMap{
-              keys: [
-                "multiline_values",
-                "purpose",
-                "does_that_mean_anything_special",
-                "can_values_be_as_well"
-              ],
-              map: %{
-                "can_values_be_as_well" => "True",
-                "does_that_mean_anything_special" => "False",
-                "multiline_values" =>
-                  "are\nhandled just fine as\nlong as they are indented\ndeeper than the first line\nof a value",
-                "purpose" => "formatting for readability"
-              },
-              size: 4
-            },
-            "Simple Values" => %OrderedMap{
-              keys: [
-                "you can also use",
-                "spaces around the delimiter",
-                "spaces in values",
-                "spaces in keys",
-                "key"
-              ],
-              map: %{
-                "key" => "value",
-                "spaces around the delimiter" => "obviously",
-                "spaces in keys" => "allowed",
-                "spaces in values" => "allowed as well",
-                "you can also use" => "to delimit keys from values"
-              },
-              size: 5
-            },
-            "You can use comments" => %OrderedMap{
-              keys: ["and also", "but not # like this"],
-              map: %{"and also" => nil, "but not # like this" => nil},
-              size: 2
-            }
-          },
-          size: 6
-        }
-      }
-    )
+      """, {:ok, %{"All Values Are Strings" => %{"are they treated as numbers?" => "no",
+     "can use the API to get converted values directly" => "true",
+     "integers, floats and booleans are held as" => "strings",
+     "or this" => "3.14159265359", "values like this" => "1000000"},
+   "Multiline Values" => %{"chorus" => "I'm a lumberjack, and I'm okay,\nI sleep all night and I work all day"},
+   "No Values" => %{"empty string value here" => "",
+     "key_without_value" => nil},
+   "Sections Can Be Indented" => %{"can_values_be_as_well" => "True",
+     "does_that_mean_anything_special" => "False",
+     "multiline_values" => "are\nhandled just fine as\nlong as they are indented\ndeeper than the first line\nof a value",
+     "purpose" => "formatting for readability"},
+   "Simple Values" => %{"key" => "value",
+     "spaces around the delimiter" => "obviously",
+     "spaces in keys" => "allowed", "spaces in values" => "allowed as well",
+     "you can also use" => "to delimit keys from values"},
+   "You can use comments" => %{
+     "but not # like this" => nil,
+     "and also" => nil}}} )
+
   end
 end

--- a/test/configparser_test.exs
+++ b/test/configparser_test.exs
@@ -14,237 +14,308 @@ defmodule ConfigParserTest do
   end
 
   test "parses comments and empty lines" do
-    check_string("""
+    check_string(
+      """
       #this is a useless file
 
         # filled with comments and empty lines
-      """, {:ok, %{}} )
+      """,
+      {:ok, %{}}
+    )
   end
 
   test "parses a single section" do
-    check_string("[section]\n", {:ok, %{"section" => %{}}} )
+    check_string("[section]\n", {:ok, %{"section" => %{}}})
   end
 
   test "parses a section name with a space" do
-    check_string("[section with space]\n", {:ok, %{"section with space" => %{}}} )
+    check_string("[section with space]\n", {:ok, %{"section with space" => %{}}})
   end
 
   test "parses a config option into a section" do
-    check_string("""
+    check_string(
+      """
       [section]
       # this is an interesting key value pair
       key = value
-      """, {:ok, %{"section" => %{"key" => "value"}}} )
+      """,
+      {:ok, %{"section" => %{"key" => "value"}}}
+    )
   end
 
   test "allows spaces in the keys" do
-    check_string("""
+    check_string(
+      """
       [section]
       # this is an interesting key value pair
       spaces in keys=allowed
-      """, {:ok, %{"section" => %{"spaces in keys" => "allowed"}}} )
+      """,
+      {:ok, %{"section" => %{"spaces in keys" => "allowed"}}}
+    )
   end
 
   test "allows spaces in the values" do
-    check_string("""
+    check_string(
+      """
       [section]
       # this is an interesting key value pair
       spaces in values=allowed as well
-      """, {:ok, %{"section" => %{"spaces in values" => "allowed as well"}}} )
+      """,
+      {:ok, %{"section" => %{"spaces in values" => "allowed as well"}}}
+    )
   end
 
   test "allows spaces around the delimiter" do
-    check_string("""
+    check_string(
+      """
       [section]
       # this is an interesting key value pair
       spaces around the delimiter = obviously
-      """, {:ok, %{"section" => %{"spaces around the delimiter" => "obviously"}}} )
+      """,
+      {:ok, %{"section" => %{"spaces around the delimiter" => "obviously"}}}
+    )
   end
 
   test "allows a colon as the delimiter" do
-    check_string("""
+    check_string(
+      """
       [section]
       # this is an interesting key value pair
       you can also use : to delimit keys from values
-      """, {:ok, %{"section" => %{"you can also use" => "to delimit keys from values"}}} )
+      """,
+      {:ok, %{"section" => %{"you can also use" => "to delimit keys from values"}}}
+    )
   end
 
   test "allows a continuation line" do
-    check_string("""
+    check_string(
+      """
       [section]
       you can also use : to delimit keys from values
           and add a continuation
-      """, {:ok, %{"section" => %{"you can also use" => "to delimit keys from values\nand add a continuation"}}} )
+      """,
+      {:ok,
+       %{
+         "section" => %{
+           "you can also use" => "to delimit keys from values\nand add a continuation"
+         }
+       }}
+    )
   end
 
   test "allows a multi-line continuation" do
-    check_string("""
+    check_string(
+      """
       [section]
       you can also use : to delimit keys 
           from values
           and add a continuation
-      """, {:ok, %{"section" => %{"you can also use" => "to delimit keys\nfrom values\nand add a continuation"}}} )
+      """,
+      {:ok,
+       %{
+         "section" => %{
+           "you can also use" => "to delimit keys\nfrom values\nand add a continuation"
+         }
+       }}
+    )
   end
 
   test "allows empty string thing" do
-    check_string("""
+    check_string(
+      """
       [No Values]
       empty string value here =
-      """, {:ok, %{"No Values" => %{"empty string value here" => ""}}} )
+      """,
+      {:ok, %{"No Values" => %{"empty string value here" => ""}}}
+    )
   end
 
   test "allows lone keys" do
-    check_string("""
+    check_string(
+      """
       [No Values]
       key_without_value
-      """, {:ok, %{"No Values" => %{"key_without_value" => nil}}} )
+      """,
+      {:ok, %{"No Values" => %{"key_without_value" => nil}}}
+    )
   end
 
   test "parses a config option with an inline comment" do
-    check_string("""
+    check_string(
+      """
       [section]
       # this is an interesting key value pair
       key = value ; With a comment
-      """, {:ok, %{"section" => %{"key" => "value"}}} )
+      """,
+      {:ok, %{"section" => %{"key" => "value"}}}
+    )
   end
 
   test "close StringIO after read" do
-    process_count_before = Process.list |> length
+    process_count_before = Process.list() |> length
     ConfigParser.parse_string("test")
-    process_count_after = Process.list |> length
+    process_count_after = Process.list() |> length
     assert process_count_before == process_count_after
   end
 
   test "extracts a list of sections from parsed config data" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [first_section]
-        boring = value
-        [second_section]
-        someother_key = and_value
-        """)
-      sorted_sections = Enum.sort(ConfigParser.sections(parse_result), &(&1 < &2))
-      assert sorted_sections == ["first_section", "second_section"]
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [first_section]
+      boring = value
+      [second_section]
+      someother_key = and_value
+      """)
+
+    sorted_sections = Enum.sort(ConfigParser.sections(parse_result), &(&1 < &2))
+    assert sorted_sections == ["first_section", "second_section"]
   end
 
   test "determines if a particular section is found in the parsed results" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [first_section]
-        boring = value
-        [second_section]
-        someother_key = and_value
-        """)
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [first_section]
+      boring = value
+      [second_section]
+      someother_key = and_value
+      """)
 
-      assert true == ConfigParser.has_section?(parse_result, "first_section")
-      assert false == ConfigParser.has_section?(parse_result, "snarfblat")
+    assert true == ConfigParser.has_section?(parse_result, "first_section")
+    assert false == ConfigParser.has_section?(parse_result, "snarfblat")
   end
 
   test "returns a list of the options defined in a particular section" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [section]
-        one = for the money
-        two = for the show
-        three = to get ready
-        """)
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      two = for the show
+      three = to get ready
+      """)
 
-      sorted_options = Enum.sort(ConfigParser.options(parse_result, "section"), &(&1 < &2))
-      assert sorted_options == ["one", "three", "two"]
+    sorted_options = Enum.sort(ConfigParser.options(parse_result, "section"), &(&1 < &2))
+    assert sorted_options == ["one", "three", "two"]
 
-      assert nil == ConfigParser.options(parse_result, "non-existant section")
+    assert nil == ConfigParser.options(parse_result, "non-existant section")
   end
 
   test "determines if a particuliar option is available in a section" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [section]
-        one = for the money
-        two = for the show
-        three = to get ready
-        """)
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      two = for the show
+      three = to get ready
+      """)
 
-      assert ConfigParser.has_option?(parse_result, "section", "one") == true
-      assert ConfigParser.has_option?(parse_result, "section", "florp") == false
+    assert ConfigParser.has_option?(parse_result, "section", "one") == true
+    assert ConfigParser.has_option?(parse_result, "section", "florp") == false
   end
 
   test "returns nil if asked for a value in a section that doesn't exist" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [section]
-        one = for the money
-        """)
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      """)
 
-      assert ConfigParser.get(parse_result, "non-existant", "one") == nil
+    assert ConfigParser.get(parse_result, "non-existant", "one") == nil
   end
 
   test "returns the value of a particular option when no fancy options are provided" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [section]
-        one = for the money
-        """)
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      """)
 
-      assert ConfigParser.get(parse_result, "section", "one") == "for the money"
+    assert ConfigParser.get(parse_result, "section", "one") == "for the money"
   end
 
   test "allows the :vars option to override definitions from the parse data" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [section]
-        one = for the money
-        """)
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      """)
 
-      assert ConfigParser.get(parse_result, "section", "one", vars: %{
-          "one" => "is the loneliest number"
-        }) == "is the loneliest number"
+    assert ConfigParser.get(parse_result, "section", "one",
+             vars: %{
+               "one" => "is the loneliest number"
+             }
+           ) == "is the loneliest number"
 
-      assert ConfigParser.get(parse_result, "section", "one", vars: %{
-          "one" => nil
-        }) == nil
+    assert ConfigParser.get(parse_result, "section", "one",
+             vars: %{
+               "one" => nil
+             }
+           ) == nil
   end
 
   test "returns the fallback value if the value can't be found otherwise" do
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [section]
-        one = for the money
-        """)
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+      [section]
+      one = for the money
+      """)
 
-      assert ConfigParser.get(parse_result, "non-existant", "_", fallback: "None") == "None"
-      assert ConfigParser.get(parse_result, "section", "non-existant", fallback: "None") == "None"
+    assert ConfigParser.get(parse_result, "non-existant", "_", fallback: "None") == "None"
+    assert ConfigParser.get(parse_result, "section", "non-existant", fallback: "None") == "None"
   end
 
   test "correctly handles the case where a section is repeated or reopened" do
-    {:ok, parse_result} = ConfigParser.parse_string("""
-      [Simple Values]
-      key=value
-      spaces in keys=allowed
+    {:ok, parse_result} =
+      ConfigParser.parse_string("""
+        [Simple Values]
+        key=value
+        spaces in keys=allowed
 
-      [Simple Values]
-      spaces in values=allowed as well
-      spaces around the delimiter = obviously
-      you can also use : to delimit keys from values
-    """)
+        [Simple Values]
+        spaces in values=allowed as well
+        spaces around the delimiter = obviously
+        you can also use : to delimit keys from values
+      """)
 
     assert ConfigParser.get(parse_result, "Simple Values", "key") == "value"
-    assert ConfigParser.get(parse_result, "Simple Values", "spaces in values") == "allowed as well"
+
+    assert ConfigParser.get(parse_result, "Simple Values", "spaces in values") ==
+             "allowed as well"
   end
 
   describe "parsing options" do
     test "errors out with unrecognized options" do
-      assert {:error, _} = ConfigParser.parse_string("""
-        [does not matter]
-        this = is_bogus
-      """, unrecognized_option: "whatever")
+      assert {:error, _} =
+               ConfigParser.parse_string(
+                 """
+                   [does not matter]
+                   this = is_bogus
+                 """,
+                 unrecognized_option: "whatever"
+               )
     end
-    
+
     test "parses multiline_values when asked for spaces" do
+      {:ok, parse_result} =
+        ConfigParser.parse_string(
+          """
+          [section]
+          you can also use : to delimit keys from values
+              and add a continuation
+          """,
+          join_continuations: :with_space
+        )
 
-      {:ok, parse_result} = ConfigParser.parse_string("""
-        [section]
-        you can also use : to delimit keys from values
-            and add a continuation
-        """, join_continuations: :with_space)
-
-      assert parse_result == %{"section" => %{"you can also use" => "to delimit keys from values and add a continuation"}}
+      assert parse_result == %{
+               "section" => %{
+                 "you can also use" => "to delimit keys from values and add a continuation"
+               }
+             }
     end
   end
 
   test "parses extended example from python page" do
-    check_string("""
+    check_string(
+      """
       [Simple Values]
       key=value
       spaces in keys=allowed
@@ -289,24 +360,39 @@ defmodule ConfigParserTest do
                   deeper than the first line
                   of a value
               # Did I mention we can indent comments, too?
-      """, {:ok, %{"All Values Are Strings" => %{"are they treated as numbers?" => "no",
-     "can use the API to get converted values directly" => "true",
-     "integers, floats and booleans are held as" => "strings",
-     "or this" => "3.14159265359", "values like this" => "1000000"},
-   "Multiline Values" => %{"chorus" => "I'm a lumberjack, and I'm okay,\nI sleep all night and I work all day"},
-   "No Values" => %{"empty string value here" => "",
-     "key_without_value" => nil},
-   "Sections Can Be Indented" => %{"can_values_be_as_well" => "True",
-     "does_that_mean_anything_special" => "False",
-     "multiline_values" => "are\nhandled just fine as\nlong as they are indented\ndeeper than the first line\nof a value",
-     "purpose" => "formatting for readability"},
-   "Simple Values" => %{"key" => "value",
-     "spaces around the delimiter" => "obviously",
-     "spaces in keys" => "allowed", "spaces in values" => "allowed as well",
-     "you can also use" => "to delimit keys from values"},
-   "You can use comments" => %{
-     "but not # like this" => nil,
-     "and also" => nil}}} )
-
+      """,
+      {:ok,
+       %{
+         "All Values Are Strings" => %{
+           "are they treated as numbers?" => "no",
+           "can use the API to get converted values directly" => "true",
+           "integers, floats and booleans are held as" => "strings",
+           "or this" => "3.14159265359",
+           "values like this" => "1000000"
+         },
+         "Multiline Values" => %{
+           "chorus" => "I'm a lumberjack, and I'm okay,\nI sleep all night and I work all day"
+         },
+         "No Values" => %{"empty string value here" => "", "key_without_value" => nil},
+         "Sections Can Be Indented" => %{
+           "can_values_be_as_well" => "True",
+           "does_that_mean_anything_special" => "False",
+           "multiline_values" =>
+             "are\nhandled just fine as\nlong as they are indented\ndeeper than the first line\nof a value",
+           "purpose" => "formatting for readability"
+         },
+         "Simple Values" => %{
+           "key" => "value",
+           "spaces around the delimiter" => "obviously",
+           "spaces in keys" => "allowed",
+           "spaces in values" => "allowed as well",
+           "you can also use" => "to delimit keys from values"
+         },
+         "You can use comments" => %{
+           "but not # like this" => nil,
+           "and also" => nil
+         }
+       }}
+    )
   end
 end


### PR DESCRIPTION
## Why?

Sometimes, the order of keys in parsed content matter.

## How?

The commits are self-explained.

> Note: In order to test `configparser_ex` with different configurations, I had to create an `alias` called `test.all`. 
When you test the code, use `mix test.all` instead of `mix test`.

* * *

Feel free to comment, rebase, or anything. ;)