### PR TITLE
Adding the capability to enumerate sections

### DIFF
--- a/lib/ConfigParser/ParseState.ex
+++ b/lib/ConfigParser/ParseState.ex
@@ -2,7 +2,8 @@
     @moduledoc false
 
     @default_options %{
-      join_continuations: :with_newline
+      join_continuations: :with_newline,
+      overwrite_sections: true
     }
 
     defstruct line_number: 1,               # What line of the "file" are we parsing
@@ -20,8 +21,18 @@
       # Create a new result, based on the old, with the new section added
       {:ok, section_map} = parse_state.result
 
-      # Only add a new section if it's not already there
-      section_key = String.trim(new_section)
+      section_key = 
+        if not parse_state.options.overwrite_sections do
+          # Numbering the sections with nnn_ prefix
+          section_num = Map.keys(section_map)
+                        |> Enum.count()
+                        |> Integer.to_string
+                        |> String.pad_leading(3, "0")
+          section_num<>"_"<>String.trim(new_section)
+        else
+          # Only add a new section if it's not already there
+          String.trim(new_section)
+        end
 
       new_result =
         if Map.has_key?(section_map, section_key) do

--- a/lib/configparser.ex
+++ b/lib/configparser.ex
@@ -375,7 +375,7 @@ defmodule ConfigParser do
   end
 
   defp options_to_map([]), do: ParseState.default_options()
-  defp options_to_map(options) when is_list(options), do: Enum.into(options, %{})
+  defp options_to_map(options) when is_list(options), do: Map.merge(ParseState.default_options(), Enum.into(options , %{}))
 
   defp validate_options(%{} = options_map) do
     Enum.reduce(options_map, {:ok, options_map}, &option_reducer/2)

--- a/lib/configparser.ex
+++ b/lib/configparser.ex
@@ -400,6 +400,15 @@ defmodule ConfigParser do
     end
   end
 
+  defp validate_option({:overwrite_sections, value} = pair) do
+    if is_boolean(value) do
+      {:ok, pair}
+    else
+      {:error,
+       "The value for the overwrite_sections option should be true or false"}
+    end
+  end
+
   defp validate_option({:join_continuations, value} = pair) do
     if value == :with_newline || value == :with_space do
       {:ok, pair}


### PR DESCRIPTION
Hi,
I think your project is quite useful. I see the parsing is treating multiple sections with the same name as a sort of multiple instances of the same paragraph. This means that in case you have:

 `
      [Simple Values]
      key=value
      spaces in keys=allowed

      [Simple Values]
      spaces in values=allowed as well
      spaces around the delimiter = obviously
      you can also use : to delimit keys from values`

The parse result will contain only one "Simple Values" section with the merge of two key/value pairs.
I need something a little different. In the aforementioned case I need the parse result will contain 001_Simple Values and 002_Simple Values sections.
Hence I added the code in this pull request. I know that it could be implemented in a better way and there is may things we can improve. Maybe we can talk about it here. 
First of all: are you interested in this improvement?

P.S. Please be patient I'm still learning how to code in Elixir.
