### PR TITLE
Bugfix - add support for a value containing [ brackets ]

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/configparser.ex
+++ b/lib/configparser.ex
@@ -255,47 +255,68 @@ defmodule ConfigParser do
     parse_state
   end
 
+  # Regex matching a line containing a section definition "[section]"
   @section_regex ~r{^\s*\[([^\]]+)\]\s*$}
+
+  # Regex matching key-value pairs separated by equals "key = value"
   @equals_definition_regex ~r{^\s*([^=]+?)\s*=\s*(.*)$}
+
+  # Regex matching key-value pairs separated by colon "key: value"
   @colon_definition_regex ~r{^\s*([^:]+?)\s*:\s*(.*)$}
+
+  # Regex matching a standalone value line (no delimiter), interpreted as a key with nil value
   @value_like_regex ~r{^\s*(\S.*)$}
 
+  # Parse a line while the parse state indicates we're in a good state
   defp parse_line(line, parse_state = %ParseState{result: {:ok, _}}) do
     line = strip_inline_comments(line)
+
+    # find out how many whitespace characters are on the front of the line
     indent_level = indent_level(line)
 
     cond do
       parse_state.continuation? && indent_level > parse_state.last_indent &&
    Regex.run(@value_like_regex, line) ->
+        # note that we do not increase the "last indent"
         %{
    ParseState.append_continuation(parse_state, String.trim(line))
    | line_number: parse_state.line_number + 1,
      continuation?: true
         }
 
+      # if we can skip this line (it's empty or a comment) then simply advance the line number
+      # and note that the next line can't be a continuation
       can_skip_line(line) ->
         %{parse_state | line_number: parse_state.line_number + 1, continuation?: false, last_indent: indent_level}
 
+
+      # match a line that begins a new section like "[new_section]"
       match = Regex.run(@section_regex, line) ->
         [_, new_section] = match
         %{ParseState.begin_section(parse_state, new_section)
    | line_number: parse_state.line_number + 1, last_indent: indent_level}
 
+
+      # match a line that defines a value "key = value"
       match = Regex.run(@equals_definition_regex, line) ->
         [_, key, value] = match
         %{ParseState.define_config(parse_state, key, value)
    | line_number: parse_state.line_number + 1, last_indent: indent_level}
 
+      # match a line that defines a value "key : value"
       match = Regex.run(@colon_definition_regex, line) ->
         [_, key, value] = match
         %{ParseState.define_config(parse_state, key, value)
    | line_number: parse_state.line_number + 1, last_indent: indent_level}
 
+      # when there's a value-ish line that on a line by itself, but which is not a continuation
+      # then it actually represents a key that has no associated value (or a value of nil)
       match = Regex.run(@value_like_regex, line) ->
         [_, key] = match
         %{ParseState.define_config(parse_state, key, nil)
    | continuation?: false, line_number: parse_state.line_number + 1, last_indent: indent_level}
 
+      # Any non-matching lines result in a syntax error
       true ->
         %{parse_state | result: {:error, "Syntax Error on line #{parse_state.line_number}"}}
     end

--- a/test/configparser_test.exs
+++ b/test/configparser_test.exs
@@ -207,6 +207,30 @@ defmodule ConfigParserTest do
       assert ConfigParser.get(parse_result, "section", "non-existant", fallback: "None") == "None"
   end
 
+  test "correctly handles a value with brackets [ ]" do
+    {:ok, parse_result} = ConfigParser.parse_string("""
+      [section]
+      key=[value]
+      spaces in keys=allowed
+      bracketsinvalues=allowed
+
+      [section2]
+      inanothersection=sure
+      mixed spacing conventions = [ of course ]
+      even with quotes and odd spacing = "[ yes]"
+
+      [section 3]
+      key=value1
+      key=value2
+      key=value3
+      key4= Preston Says Hi
+      key=value5
+    """)
+
+    assert ConfigParser.get(parse_result, "section", "key") == "[value]"
+    assert ConfigParser.get(parse_result, "section 3", "key4") == "Preston Says Hi"
+  end
+
   test "correctly handles the case where a section is repeated or reopened" do
     {:ok, parse_result} = ConfigParser.parse_string("""
       [Simple Values]


### PR DESCRIPTION
When trying to include an IPv6 literal within a configuration file, a value containing an IPv6 address such as [2001:db8::1] would be parsed as a section.

Previous behavior:
[section]
key1=value1
key2=[value2]
[section2]
key1=value1

in this instance, [value2] would be parsed as entirely new section, even if it were encapsulated in quotes.  It now follows the otherwise expected behavior and will key2 would map to [value2].

A test was added and all other tests passed.

The parse_line function has also been cleaned up.

Mix.Config was also migrated Config to clear deprecation warnings.