### PR TITLE
Add markdown formatter to docs output

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule ConfigParser.Mixfile do
       extras: ["CHANGELOG.md", {:"README.md", [title: "Overview"]}],
       main: "readme",
       source_url: @source_url,
-      formatters: ["html"]
+      formatters: ["html", "markdown"]
     ]
   end
 end


### PR DESCRIPTION
ex_doc v0.40.0 added a Markdown formatter and generates `llms.txt` by default. Because configparser_ex pins an explicit `formatters:` list, that default does not apply.

This adds only `"markdown"` to the existing list; HTML output is unchanged. After the next docs publish, HexDocs will expose `llms.txt` and individual Markdown pages.

Note: the currently published docs predate this ex_doc behavior, so the Markdown output will appear after the next `mix hex.publish docs`; merging alone will not change HexDocs.

This change was generated from [Elixir's retrieval gap is a rollout problem, not an access problem](https://phxagents.dev/research/elixir-retrieval-gap/).

— Oliver’s AMP